### PR TITLE
Support Gatsby v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prepack": "yarn lint && yarn build"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0",
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "linaria": "^2.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
While upgrading to Gatsby v4 getting below warning.
```
warn Plugin gatsby-plugin-linaria is not compatible with your gatsby version 4.4.0 - It requires gatsby@^2.0.0 || ^3.0.0
```

This PR adds support for Gatsby v4